### PR TITLE
Add 30min Calendly booking option

### DIFF
--- a/calendar-30.html
+++ b/calendar-30.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="refresh" content="0; url=https://calendly.com/j-jaykhatri/chat-w-jay-30min">
+    <title>Redirecting to Calendar...</title>
+</head>
+<body>
+    <p>If you are not redirected automatically, <a href="https://calendly.com/j-jaykhatri/chat-w-jay-30min">click here</a>.</p>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
 
       <p>I currently run the Observability business at LaunchDarkly<a href="#links"><sup>[1]</sup></a>. 
         If you want to get in touch, dm me on
-        x<a href="#links"><sup>[2]</sup></a>, linkedin<a href="#links"><sup>[3]</sup></a>, email<a href="mailto:j@jaykhatri.com"><sup>[4]</sup></a>, or schedule a chat (<a href="https://calendly.com/j-jaykhatri/chat-w-jay-15min-clone">15min</a> / <a href="https://calendly.com/j-jaykhatri/chat-w-jay-30min">30min</a>).
+        x<a href="#links"><sup>[2]</sup></a>, linkedin<a href="#links"><sup>[3]</sup></a>, or email<a href="mailto:j@jaykhatri.com"><sup>[4]</sup></a>.
 
       <h3>Past</h3>
       <p>

--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
       </h1>
       <p>
         If you want to get in touch, dm me on
-        <a href="https://x.com/theJayKhatri">x</a>, <a href="https://linkedin.com/in/jay-khatri">linkedin </a>, <a href="mailto:jay@highlight.io">email</a>, or <a href="https://calendly.com/j-jaykhatri/chat-w-jay-15min-clone">schedule a chat</a>.
+        <a href="https://x.com/theJayKhatri">x</a>, <a href="https://linkedin.com/in/jay-khatri">linkedin </a>, <a href="mailto:jay@highlight.io">email</a>, or schedule a chat (<a href="https://calendly.com/j-jaykhatri/chat-w-jay-15min-clone">15min</a> / <a href="https://calendly.com/j-jaykhatri/chat-w-jay-30min">30min</a>).
       </p>
       <h3>Current</h3>
 

--- a/index.html
+++ b/index.html
@@ -100,16 +100,17 @@
         data-large="static/profile.png"
       />
       <h1>
-        I'm Jay. I'm working on
-        <a target="_blank" href="https://highlight.io">Highlight.io</a>.
+        I'm Jay.
       </h1>
       <p>
         If you want to get in touch, dm me on
-        <a href="https://x.com/theJayKhatri">x</a>, <a href="https://linkedin.com/in/jay-khatri">linkedin </a>, or <a href="mailto:jay@highlight.io">email</a>.
+        <a href="https://x.com/theJayKhatri">x</a>, <a href="https://linkedin.com/in/jay-khatri">linkedin </a>, <a href="mailto:jay@highlight.io">email</a>, or <a href="https://calendly.com/j-jaykhatri/chat-w-jay-15min-clone">schedule a chat</a>.
       </p>
       <h3>Current</h3>
 
-      <p>I'm currently the ceo @ Highlight.io; we're building an <a href="https://github.com/highlight/highlight">open source</a> observability distribution. I occasionally invest in founders who I develop good relationships with. Most of these businesses are in the dev-tools/infra spaces. Some of the public investments I've made include <a href="https://openmeter.io">OpenMeter</a>, <a href="https://magicpatterns.com">MagicPatterns</a>, and <a href="https://trigger.dev">Trigger.dev</a>.</p>
+      <p>• I'm currently the ceo @ Highlight.io; we're building an <a href="https://github.com/highlight/highlight">open source</a> observability distribution. I occasionally invest in founders who I develop good relationships with. Most of these businesses are in the dev-tools/infra spaces. Some of the public investments I've made include <a href="https://openmeter.io">OpenMeter</a>, <a href="https://magicpatterns.com">MagicPatterns</a>, and <a href="https://trigger.dev">Trigger.dev</a>.</p>
+
+      <p>• I'm currently the ceo @ Highlight.io; we're building an <a href="https://github.com/highlight/highlight">open source</a> observability distribution. I occasionally invest in founders who I develop good relationships with. Most of these businesses are in the dev-tools/infra spaces. Some of the public investments I've made include <a href="https://openmeter.io">OpenMeter</a>, <a href="https://magicpatterns.com">MagicPatterns</a>, and <a href="https://trigger.dev">Trigger.dev</a>.</p>
 
       <h3>Past</h3>
       <p>


### PR DESCRIPTION
## Summary
• Add 30-minute Calendly booking link alongside existing 15-minute option
• Update contact section to show both booking duration options (15min / 30min)

## Test plan
- [ ] Verify both Calendly links work correctly
- [ ] Check that the contact section displays properly with both options

🤖 Generated with [Claude Code](https://claude.ai/code)