### PR TITLE
Add Queryplane to angel investments

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@ I was the CEO at Highlight, which was acquired by LaunchDarkly in March of 2025.
 
       <h3>Investing</h3>
       <p>
-I occasionally invest in fellow founders' businesses. Most of these businesses are in the dev-tools/infra spaces. Some of the public investments I've made include OpenMeter<a href="#links"><sup>[8]</sup></a>, MagicPatterns<a href="#links"><sup>[9]</sup></a>, and Trigger.dev<a href="#links"><sup>[10]</sup></a>.</p>
+I occasionally invest in fellow founders' businesses. Most of these businesses are in the dev-tools/infra spaces. Some of the public investments I've made include OpenMeter<a href="#links"><sup>[8]</sup></a>, MagicPatterns<a href="#links"><sup>[9]</sup></a>, Trigger.dev<a href="#links"><sup>[10]</sup></a>, and Queryplane<a href="#links"><sup>[11]</sup></a>.</p>
 
       </p>
 
@@ -154,7 +154,8 @@ I occasionally invest in fellow founders' businesses. Most of these businesses a
           7. <a href="https://www.theledger.com/story/news/2014/03/13/polk-tampa-teens-robotics-team-headed-to-world-championship/26940999007/" target="_blank">Robotics Team News Article</a><br/>
           8. <a href="https://openmeter.io" target="_blank">OpenMeter Website</a><br/>
           9. <a href="https://magicpatterns.com" target="_blank">MagicPatterns Website</a><br/>
-          10. <a href="https://trigger.dev" target="_blank">Trigger.dev Website</a>
+          10. <a href="https://trigger.dev" target="_blank">Trigger.dev Website</a><br/>
+          11. <a href="https://queryplane.com" target="_blank">Queryplane Website</a>
         </p>
       </div>
 


### PR DESCRIPTION
## Summary
- Adds Queryplane to the list of public angel investments on the personal website
- Adds corresponding link entry (#11) pointing to queryplane.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)